### PR TITLE
Add Roku & Fitbit badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -811,6 +811,14 @@ You can reach me on [Twitter @ileriayooo](https://twitter.com/Ileriayooo)
 
 [(Back to top)](#table-of-contents)
 
+### Wearable Brands
+
+| Name       | Badge                                                                                                                 | Markdown                                                                                                                |
+| ---------- | --------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| Fitbit      | ![Fitbit](https://img.shields.io/badge/fitbit-00B0B9?style=for-the-badge&logo=fitbit&logoColor=white)             | `![Fitbit](https://img.shields.io/badge/fitbit-00B0B9?style=for-the-badge&logo=fitbit&logoColor=white)`             |
+
+[(Back to top)](#table-of-contents)
+
 ### Smartphone Brands
 
 | Name       | Badge                                                                                                                 | Markdown                                                                                                                |
@@ -851,6 +859,7 @@ You can reach me on [Twitter @ileriayooo](https://twitter.com/Ileriayooo)
 | Fire TV         | ![Fire TV](https://img.shields.io/badge/fire%20tv-fc3b2d?style=for-the-badge&logo=amazon%20fire%20tv&logoColor=white)             | `![Fire TV](https://img.shields.io/badge/fire%20tv-fc3b2d?style=for-the-badge&logo=amazon%20fire%20tv&logoColor=white)`             |
 | Hulu            | ![Hulu](https://img.shields.io/badge/hulu-1CE783?style=for-the-badge&logo=hulu&logoColor=white)                                   | `![Hulu](https://img.shields.io/badge/hulu-1CE783?style=for-the-badge&logo=hulu&logoColor=white)`                                   |
 | Netflix         | ![Netflix](https://img.shields.io/badge/Netflix-E50914?style=for-the-badge&logo=netflix&logoColor=white)                          | `![Netflix](https://img.shields.io/badge/Netflix-E50914?style=for-the-badge&logo=netflix&logoColor=white)`                          |
+| Roku  | ![Roku](https://img.shields.io/badge/roku-6f1ab1?style=for-the-badge&logo=roku&logoColor=white)    | `![Roku](https://img.shields.io/badge/roku-6f1ab1?style=for-the-badge&logo=roku&logoColor=white)`    |
 | Twitch          | ![Twitch](https://img.shields.io/badge/Twitch-9347FF?style=for-the-badge&logo=twitch&logoColor=white)                             | `![Twitch](https://img.shields.io/badge/Twitch-9347FF?style=for-the-badge&logo=twitch&logoColor=white)`                             |
 | Youtube Gaming  | ![Youtube Gaming](https://img.shields.io/badge/Youtube%20Gaming-FF0000?style=for-the-badge&logo=Youtubegaming&logoColor=white)    | `![Youtube Gaming](https://img.shields.io/badge/Youtube%20Gaming-FF0000?style=for-the-badge&logo=Youtubegaming&logoColor=white)`    |
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ Add badges to your Profile and Projects.
      - [Quantum Programming Frameworks and Libraries](#quantum-programming-frameworks-and-libraries)
      - [Search Engines](#search-engines)
      - [Servers](#servers)
-     - [Smartphone Brands](#wearable-brands)
      - [Smartphone Brands](#smartphone-brands)
      - [Social](#social)
      - [Store](#store)

--- a/README.md
+++ b/README.md
@@ -42,12 +42,14 @@ Add badges to your Profile and Projects.
      - [Quantum Programming Frameworks and Libraries](#quantum-programming-frameworks-and-libraries)
      - [Search Engines](#search-engines)
      - [Servers](#servers)
+     - [Smartphone Brands](#wearable-brands)
      - [Smartphone Brands](#smartphone-brands)
      - [Social](#social)
      - [Store](#store)
      - [Streaming](#streaming)
      - [Testing](#testing)
      - [Version Control](#version-control)
+     - [Wearables](#wearables)
      - [Work/Jobs](#workjobs)
    </details>
 
@@ -811,14 +813,6 @@ You can reach me on [Twitter @ileriayooo](https://twitter.com/Ileriayooo)
 
 [(Back to top)](#table-of-contents)
 
-### Wearable Brands
-
-| Name       | Badge                                                                                                                 | Markdown                                                                                                                |
-| ---------- | --------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| Fitbit      | ![Fitbit](https://img.shields.io/badge/fitbit-00B0B9?style=for-the-badge&logo=fitbit&logoColor=white)             | `![Fitbit](https://img.shields.io/badge/fitbit-00B0B9?style=for-the-badge&logo=fitbit&logoColor=white)`             |
-
-[(Back to top)](#table-of-contents)
-
 ### Smartphone Brands
 
 | Name       | Badge                                                                                                                 | Markdown                                                                                                                |
@@ -891,6 +885,14 @@ You can reach me on [Twitter @ileriayooo](https://twitter.com/Ileriayooo)
 | Gitpod         | ![Gitpod](https://img.shields.io/badge/gitpod-f06611.svg?style=for-the-badge&logo=gitpod&logoColor=white)                  | `![Gitpod](https://img.shields.io/badge/gitpod-f06611.svg?style=for-the-badge&logo=gitpod&logoColor=white)`                  |
 | Mercurial      | ![Mercurial](https://img.shields.io/badge/mercurial-999999.svg?style=for-the-badge&logo=mercurial&logoColor=white)         | `![Mercurial](https://img.shields.io/badge/mercurial-999999.svg?style=for-the-badge&logo=mercurial&logoColor=white)`         |
 | Perforce Helix | ![Perforce Helix](https://img.shields.io/badge/-PERFORCE%20HELIX-404040?style=for-the-badge&logo=Perforce&logoColor=white) | `![Perforce Helix](https://img.shields.io/badge/-PERFORCE%20HELIX-00AEEF?style=for-the-badge&logo=Perforce&logoColor=white)` |
+
+[(Back to top)](#table-of-contents)
+
+### Wearables
+
+| Name       | Badge                                                                                                                 | Markdown                                                                                                                |
+| ---------- | --------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| Fitbit      | ![Fitbit](https://img.shields.io/badge/fitbit-00B0B9?style=for-the-badge&logo=fitbit&logoColor=white)             | `![Fitbit](https://img.shields.io/badge/fitbit-00B0B9?style=for-the-badge&logo=fitbit&logoColor=white)`             |
 
 [(Back to top)](#table-of-contents)
 


### PR DESCRIPTION
## Summary
This adds a [Roku](https://roku.com/) and a [Fitbit](https://fitbit.com) badge.

## Preview
![Fitbit](https://img.shields.io/badge/fitbit-00B0B9?style=for-the-badge&logo=fitbit&logoColor=white) ![Roku](https://img.shields.io/badge/roku-6f1ab1?style=for-the-badge&logo=roku&logoColor=white)
## Why Fitbit?

People are developing [Fitbit clock faces](https://github.com/Fitbit/ossapps), and it would be useful to have a "Fitbit" or "Fitbit Gallery" badge on their project's repository.

