### PR TITLE
docs: adding simple icons slugs as resource for contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@
 
     > **:fire: Important:** All of the badges are ordered alphabetically. Hence, while contributing, make sure to order to add the new badges in an alphabetical order.
 
-    > **:bulb: Tip:** You can check available icons for your `<badge>` in [Simple Icons slugs](https://github.com/simple-icons/simple-icons/blob/develop/slugs.md).
+    > **:bulb: Tip:** You can check available icons for your `<badge>` in [Simple Icons slugs](https://github.com/simple-icons/simple-icons/blob/develop/slugs.md) or [Simple Icons website](https://simpleicons.org/).
 
 5. Create a [Pull Request](https://docs.github.com/en/get-started/quickstart/contributing-to-projects#making-a-pull-request) with your proposed changes.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,8 @@
 
     > **:fire: Important:** All of the badges are ordered alphabetically. Hence, while contributing, make sure to order to add the new badges in an alphabetical order.
 
+    > **:bulb: Tip:** You can check available icons for your `<badge>` in [Simple Icons slugs](https://github.com/simple-icons/simple-icons/blob/develop/slugs.md).
+
 5. Create a [Pull Request](https://docs.github.com/en/get-started/quickstart/contributing-to-projects#making-a-pull-request) with your proposed changes.
 
 Yayyy, You are all done with the steps! Now just sit back and watch while your Pull request is reviewed and ultimately merged. 🎊


### PR DESCRIPTION
### Description
Hi guys!
In this PR I am improving the markdown contributing text, now anyone who wants to contribute has access to the list of slugs for the icons.

What do you think about this tip?

> **:bulb: Tip:** You can check available icons for your `<badge>` in [Simple Icons slugs](https://github.com/simple-icons/simple-icons/blob/develop/slugs.md).
