### PR TITLE
add stackblitz badge to  IDEs/Editors

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,6 +571,7 @@ You can reach me on [Twitter @ileriayooo](https://twitter.com/Ileriayooo)
 | WebStorm           | ![WebStorm](https://img.shields.io/badge/webstorm-143?style=for-the-badge&logo=webstorm&logoColor=white&color=black)                              | `![WebStorm](https://img.shields.io/badge/webstorm-143?style=for-the-badge&logo=webstorm&logoColor=white&color=black)`                              |
 | Xcode              | ![Xcode](https://img.shields.io/badge/Xcode-007ACC?style=for-the-badge&logo=Xcode&logoColor=white)                                                | `![Xcode](https://img.shields.io/badge/Xcode-007ACC?style=for-the-badge&logo=Xcode&logoColor=white)`                                                |
 | Zend               | ![Zend](https://img.shields.io/badge/Zend-fff?style=for-the-badge&logo=zend&logoColor=0679EA)                                                     | `![Zend](https://img.shields.io/badge/Zend-fff?style=for-the-badge&logo=zend&logoColor=0679EA)`                                                     |
+| Stackblitz               | ![Stackblitz](https://img.shields.io/badge/Stackblitz-fff?style=for-the-badge&logo=Stackblitz&logoColor=1389FD)                                                     | `![Stackblitz](https://img.shields.io/badge/Stackblitz-fff?style=for-the-badge&logo=Stackblitz&logoColor=1389FD)`                                                     |
 
 [(Back to top)](#table-of-contents)
 


### PR DESCRIPTION
adding Stack Blitz badge to IDEs/Editors group

## Description
<!-- For example, Render is a ....  -->

## Info
<!-- Badge Name: Render -->
Badge Name: StackBlitz

<!-- Badge Category: Frameworks -->
Badge Category: IDEs/Editors

<!-- Background Color(Hex): #46E3B7 -->
Background Color: fff


<!-- Logo Color(Hex): #FFFFFF -->
Logo Color: 1389FD


## Badge Url
<!-- Paste badge url-->
https://img.shields.io/badge/Stackblitz-fff?style=for-the-badge&logo=Stackblitz&logoColor=1389FD

