### PR TITLE
Add Vitest Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -939,6 +939,7 @@ You can reach me on [Twitter @ileriayooo](https://twitter.com/Ileriayooo)
 | Mocha           | ![Mocha](https://img.shields.io/badge/-mocha-%238D6748?style=for-the-badge&logo=mocha&logoColor=white)                              | `![Mocha](https://img.shields.io/badge/-mocha-%238D6748?style=for-the-badge&logo=mocha&logoColor=white)`                              |
 | Selenium        | ![Selenium](https://img.shields.io/badge/-selenium-%43B02A?style=for-the-badge&logo=selenium&logoColor=white)                       | `![Selenium](https://img.shields.io/badge/-selenium-%43B02A?style=for-the-badge&logo=selenium&logoColor=white)`                       |
 | Testing Library | ![Testing-Library](https://img.shields.io/badge/-TestingLibrary-%23E33332?style=for-the-badge&logo=testing-library&logoColor=white) | `![Testing-Library](https://img.shields.io/badge/-TestingLibrary-%23E33332?style=for-the-badge&logo=testing-library&logoColor=white)` |
+| Vitest | ![Vitest](https://img.shields.io/badge/-Vitest-%6DA13F?style=for-the-badge&logo=vitest&logoColor=FCC72B) | `![Vitest](https://img.shields.io/badge/-Vitest-%6DA13F?style=for-the-badge&logo=vitest&logoColor=FCC72B)` |
 
 [(Back to top)](#table-of-contents)
 

--- a/README.md
+++ b/README.md
@@ -939,7 +939,7 @@ You can reach me on [Twitter @ileriayooo](https://twitter.com/Ileriayooo)
 | Mocha           | ![Mocha](https://img.shields.io/badge/-mocha-%238D6748?style=for-the-badge&logo=mocha&logoColor=white)                              | `![Mocha](https://img.shields.io/badge/-mocha-%238D6748?style=for-the-badge&logo=mocha&logoColor=white)`                              |
 | Selenium        | ![Selenium](https://img.shields.io/badge/-selenium-%43B02A?style=for-the-badge&logo=selenium&logoColor=white)                       | `![Selenium](https://img.shields.io/badge/-selenium-%43B02A?style=for-the-badge&logo=selenium&logoColor=white)`                       |
 | Testing Library | ![Testing-Library](https://img.shields.io/badge/-TestingLibrary-%23E33332?style=for-the-badge&logo=testing-library&logoColor=white) | `![Testing-Library](https://img.shields.io/badge/-TestingLibrary-%23E33332?style=for-the-badge&logo=testing-library&logoColor=white)` |
-| Vitest | ![Vitest](https://img.shields.io/badge/-Vitest-%6DA13F?style=for-the-badge&logo=vitest&logoColor=FCC72B) | `![Vitest](https://img.shields.io/badge/-Vitest-%6DA13F?style=for-the-badge&logo=vitest&logoColor=FCC72B)` |
+| Vitest | ![Vitest](https://img.shields.io/badge/-Vitest-252529?style=for-the-badge&logo=vitest&logoColor=FCC72B) | `![Vitest](https://img.shields.io/badge/-Vitest-252529?style=for-the-badge&logo=vitest&logoColor=FCC72B)` |
 
 [(Back to top)](#table-of-contents)
 


### PR DESCRIPTION
## Description
This commit resolves issue #560

## Info
<!-- This is an example. Replace with badge details-->
|Name|Category|Background Color|Logo Color|
|:--:|:--:|:--:|:--:|
Vitest|Testing| `#252529`|`#FCC72B`


## Preview
<!-- This is an example. Replace with badge url-->
| Badge | url |
| ----- | --- |
| ![Vitest](https://img.shields.io/badge/-Vitest-252529?style=for-the-badge&logo=vitest&logoColor=FCC72B) | `![Vitest](https://img.shields.io/badge/-Vitest-%252529?style=for-the-badge&logo=vitest&logoColor=FCC72B)` |
