### PR TITLE
Fixed broken bitcoin markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,8 +135,7 @@ You can reach me on [Twitter @ileriayooo](https://twitter.com/Ileriayooo)
 
 | Name        | Badge                                                                                                                | Markdown                                                                                                               |
 | ----------- | -------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| Bitcoin | ![Bitcoin](https://img.shields.io/badge/bitcoin-F7931A?style=for-the-badge&logo=bitcoin&logoColor=white) |
-`![Bitcoin](https://img.shields.io/badge/bitcoin-2F3134?style=for-the-badge&logo=bitcoin&logoColor=white)` |
+| Bitcoin     | ![Bitcoin](https://img.shields.io/badge/bitcoin-F7931A?style=for-the-badge&logo=bitcoin&logoColor=white)             |`![Bitcoin](https://img.shields.io/badge/bitcoin-2F3134?style=for-the-badge&logo=bitcoin&logoColor=white)`              |
 | Hyperledger | ![Hyperledger](https://img.shields.io/badge/hyperledger-F7931A?style=for-the-badge&logo=hyperledger&logoColor=white) | `![Hyperledger](https://img.shields.io/badge/hyperledger-2F3134?style=for-the-badge&logo=hyperledger&logoColor=white)` |
 
 [(Back to top)](#table-of-contents)


### PR DESCRIPTION
## Description
Fixed broken Bitcoin row. The Bitcoin markdown entry was in a separate row. Fixes #767 

## Info
<!-- This is an example. Replace with badge details-->
|Name|Category|Background Color|Logo Color|
|:--:|:--:|:--:|:--:|
Bitcoin|Blockchain| `#F7931A`|`#ffffff`


## Preview
<!-- This is an example. Replace with badge url-->
| Badge | url |
| ----- | --- |
| Bitcoin     | ![Bitcoin](https://img.shields.io/badge/bitcoin-F7931A?style=for-the-badge&logo=bitcoin&logoColor=white)             |`![Bitcoin](https://img.shields.io/badge/bitcoin-2F3134?style=for-the-badge&logo=bitcoin&logoColor=white)`              |