### PR TITLE
Fixed ordering and colors for Oppo and Vivo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1002,12 +1002,12 @@ Zod                | ![Zod](https://img.shields.io/badge/zod-%233068b7.svg?style
 | Lenovo     | ![Lenovo](https://img.shields.io/badge/lenovo-E2231A?style=for-the-badge&logo=lenovo&logoColor=white)                 | `![Lenovo](https://img.shields.io/badge/lenovo-E2231A?style=for-the-badge&logo=lenovo&logoColor=white)`                 |
 | LG         | ![LG](https://img.shields.io/badge/lg-a50034.svg?style=for-the-badge&logo=lg&logoColor=white)                         | `![LG](https://img.shields.io/badge/lg-a50034.svg?style=for-the-badge&logo=lg&logoColor=white)`                         |
 | OnePlus    | ![OnePlus](https://img.shields.io/badge/OnePlus-%23F5010C.svg?style=for-the-badge&logo=oneplus&logoColor=white)       | `![OnePlus](https://img.shields.io/badge/OnePlus-%23F5010C.svg?style=for-the-badge&logo=oneplus&logoColor=white)`       |
+| Oppo | ![Oppo](https://img.shields.io/badge/oppo-%232D683D.svg?style=for-the-badge&logo=oppo&logoColor=white) | `![Oppo](https://img.shields.io/badge/oppo-%232D683D.svg?style=for-the-badge&logo=oppo&logoColor=white)` |
 | Motorola   | ![Motorola](https://img.shields.io/badge/Motorola-%23E1140A.svg?style=for-the-badge&logo=motorola&logoColor=white)    | `![Motorola](https://img.shields.io/badge/Motorola-%23E1140A.svg?style=for-the-badge&logo=motorola&logoColor=white)`    |
 | Nokia      | ![Nokia](https://img.shields.io/badge/Nokia-%23124191.svg?style=for-the-badge&logo=nokia&logoColor=white)             | `![Nokia](https://img.shields.io/badge/Nokia-%23124191.svg?style=for-the-badge&logo=nokia&logoColor=white)`             |
 | Samsung    | ![Samsung](https://img.shields.io/badge/Samsung-%231428A0.svg?style=for-the-badge&logo=samsung&logoColor=white)       | `![Samsung](https://img.shields.io/badge/Samsung-%231428A0.svg?style=for-the-badge&logo=samsung&logoColor=white)`       |
+| Vivo | ![Vivo](https://img.shields.io/badge/vivo-%23415FFF.svg?style=for-the-badge&logo=vivo&logoColor=white) | `![Vivo](https://img.shields.io/badge/vivo-%23415FFF.svg?style=for-the-badge&logo=vivo&logoColor=white)` |
 | Xiaomi     | ![Xiaomi](https://img.shields.io/badge/Xiaomi-%23FF6900.svg?style=for-the-badge&logo=xiaomi&logoColor=white)          | `![Xiaomi](https://img.shields.io/badge/Xiaomi-%23FF6900.svg?style=for-the-badge&logo=xiaomi&logoColor=white)`          |
-| Oppo     | ![Oppo](https://img.shields.io/badge/Oppo-%231EA366.svg?style=for-the-badge&logo=oppo&logoColor=white)          | `![Oppo](https://img.shields.io/badge/Oppo-%231EA366.svg?style=for-the-badge&logo=oppo&logoColor=white)`          |
-| Vivo     | ![Vivo](https://img.shields.io/badge/Vivo-%2300BFFF.svg?style=for-the-badge&logo=vivo&logoColor=black)          | `![Vivo](https://img.shields.io/badge/Vivo-%2300BFFF.svg?style=for-the-badge&logo=vivo&logoColor=black)`          |
 
 
 [(Back to top)](#table-of-contents)


### PR DESCRIPTION
## Description
Oppo and Vivo ordering and colors weren't correct.

## Info
|Name|Category|Background Color|Logo Color|
|:--:|:--:|:--:|:--:|
| Oppo | Smartphone Brands | `#2D683D` | `#ffffff` |
| Vivo | Smartphone Brands | `#415FFF` | `#ffffff` |

## Preview
| Badge | url |
| ----- | --- |
| ![Oppo](https://img.shields.io/badge/oppo-%232D683D.svg?style=for-the-badge&logo=oppo&logoColor=white) | `![Oppo](https://img.shields.io/badge/oppo-%232D683D.svg?style=for-the-badge&logo=oppo&logoColor=white)` |
| ![Vivo](https://img.shields.io/badge/vivo-%23415FFF.svg?style=for-the-badge&logo=vivo&logoColor=white) | `![Vivo](https://img.shields.io/badge/vivo-%23415FFF.svg?style=for-the-badge&logo=vivo&logoColor=white)` |