### PR TITLE
Add badges for Kimi and Qwen under Artificial Intelligence and Bot category

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ You can reach me on [Twitter @ileriayooo](https://twitter.com/Ileriayooo)
 | Google Assistant | ![Google Assistant](https://img.shields.io/badge/google%20assistant-4285F4?style=for-the-badge&logo=google%20assistant&logoColor=white) | `![Google Assistant](https://img.shields.io/badge/google%20assistant-4285F4?style=for-the-badge&logo=google%20assistant&logoColor=white)` |
 | Google Gemini    | ![Google Gemini](https://img.shields.io/badge/google%20gemini-8E75B2?style=for-the-badge&logo=google%20gemini&logoColor=white)          | `![Google Gemini](https://img.shields.io/badge/google%20gemini-8E75B2?style=for-the-badge&logo=google%20gemini&logoColor=white)`          |
 | Perplexity     | ![Perplexity](https://img.shields.io/badge/perplexity-000000?style=for-the-badge&logo=perplexity&logoColor=088F8F)          | `![Perplexity](https://img.shields.io/badge/perplexity-000000?style=for-the-badge&logo=perplexity&logoColor=088F8F)`          |
+| KIMI     | ![Kimi](https://img.shields.io/badge/Kimi-%23007AFF.svg?style=for-the-badge&logo=Kimi&logoColor=white)          | `![Kimi](https://img.shields.io/badge/Kimi-%23007AFF.svg?style=for-the-badge&logo=Kimi&logoColor=white)`          |
+| QWen     | ![Qwen](https://img.shields.io/badge/Qwen-%23FF6F61.svg?style=for-the-badge&logo=Qwen&logoColor=white)          | `![Qwen](https://img.shields.io/badge/Qwen-%23FF6F61.svg?style=for-the-badge&logo=Qwen&logoColor=white)`          |
 
 [(Back to top)](#table-of-contents)
 

--- a/README.md
+++ b/README.md
@@ -129,8 +129,8 @@ You can reach me on [Twitter @ileriayooo](https://twitter.com/Ileriayooo)
 | Google Assistant | ![Google Assistant](https://img.shields.io/badge/google%20assistant-4285F4?style=for-the-badge&logo=google%20assistant&logoColor=white) | `![Google Assistant](https://img.shields.io/badge/google%20assistant-4285F4?style=for-the-badge&logo=google%20assistant&logoColor=white)` |
 | Google Gemini    | ![Google Gemini](https://img.shields.io/badge/google%20gemini-8E75B2?style=for-the-badge&logo=google%20gemini&logoColor=white)          | `![Google Gemini](https://img.shields.io/badge/google%20gemini-8E75B2?style=for-the-badge&logo=google%20gemini&logoColor=white)`          |
 | Perplexity     | ![Perplexity](https://img.shields.io/badge/perplexity-000000?style=for-the-badge&logo=perplexity&logoColor=088F8F)          | `![Perplexity](https://img.shields.io/badge/perplexity-000000?style=for-the-badge&logo=perplexity&logoColor=088F8F)`          |
-| KIMI     | ![Kimi](https://img.shields.io/badge/Kimi-%23007AFF.svg?style=for-the-badge&logo=Kimi&logoColor=white)          | `![Kimi](https://img.shields.io/badge/Kimi-%23007AFF.svg?style=for-the-badge&logo=Kimi&logoColor=white)`          |
-| QWen     | ![Qwen](https://img.shields.io/badge/Qwen-%23FF6F61.svg?style=for-the-badge&logo=Qwen&logoColor=white)          | `![Qwen](https://img.shields.io/badge/Qwen-%23FF6F61.svg?style=for-the-badge&logo=Qwen&logoColor=white)`          |
+| KIMI     | ![Kimi](https://img.shields.io/badge/Kimi-%23000000.svg?style=for-the-badge&logo=kimi&logoColor=white)          | `![Kimi](https://img.shields.io/badge/Kimi-%23000000.svg?style=for-the-badge&logo=kimi&logoColor=white)`          |
+| QWen     | ![Qwen](https://img.shields.io/badge/Qwen-%234B0082.svg?style=for-the-badge&logo=qwen&logoColor=white)          | `![Qwen](https://img.shields.io/badge/Qwen-%234B0082.svg?style=for-the-badge&logo=qwen&logoColor=white)`          |
 
 [(Back to top)](#table-of-contents)
 


### PR DESCRIPTION
## New Badges Added

This pull request adds two new badges to the `Artificial Intelligence and Bot` category:

- ![Kimi](https://img.shields.io/badge/Kimi-%23000000.svg?style=for-the-badge&logo=kimi&logoColor=white)
- ![Qwen](https://img.shields.io/badge/Qwen-%234B0082.svg?style=for-the-badge&logo=qwen&logoColor=white)

### Details

- **Kimi** is a popular Chinese AI assistant developed by Moonshot AI, widely used for advanced natural language interaction.
- **Qwen** (通义千问) is a powerful open-source LLM series developed by Alibaba, increasingly integrated into AI workflows.

### Badge Design

- Colors strictly follow brand color guidelines (black for Kimi `#000000`, indigo for Qwen `#4B0082`)
- Format follows project standards: `for-the-badge`, logo on left, text on right
- Inserted in alphabetical order in the category file

### Notes

- The `logo` fields assume Kimi and Qwen logos are or will be available in [Simple Icons](https://simpleicons.org/). If not, the badges will render without logos until support is added.
- Contributions were tested using Markdown Preview in VSCode to ensure correct rendering.

---

Looking forward to feedback and happy to make adjustments!