### PR TITLE
Added basic spoken language badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -662,24 +662,6 @@ Zod                | ![Zod](https://img.shields.io/badge/zod-%233068b7.svg?style
 | Zed               | ![Zed](https://img.shields.io/badge/zedindustries-084CCF.svg?style=for-the-badge&logo=zedindustries&logoColor=white)                                                    | `![Zed](https://img.shields.io/badge/zedindustries-084CCF.svg?style=for-the-badge&logo=zedindustries&logoColor=white)`  
 | Zend               | ![Zend](https://img.shields.io/badge/Zend-fff?style=for-the-badge&logo=zend&logoColor=0679EA)                                                     | `![Zend](https://img.shields.io/badge/Zend-fff?style=for-the-badge&logo=zend&logoColor=0679EA)`                                                     |                                                  |
                                                  |
-
-[(Back to top)](#table-of-contents)
-
-
-### 🗣 Languages
-
-| Name         | Badge                                                                                                                      | Markdown                                                                                                                     |
-| ------------ | -------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| Arabic    | ![Arabic](https://img.shields.io/badge/Arabic-%23046005.svg?style=for-the-badge&logo=<badge>&logoColor=white)      | `![Arabic](https://img.shields.io/badge/Arabic-%23#046005.svg?style=for-the-badge&logo=<badge>&logoColor=white)`      |
-| Chinese    | ![Chinese](https://img.shields.io/badge/Chinese-%23c80000.svg?style=for-the-badge&logo=<badge>&logoColor=white)      | `![Chinese](https://img.shields.io/badge/Chinese-%23#c80000.svg?style=for-the-badge&logo=<badge>&logoColor=white)`      |
-| English      | ![English](https://img.shields.io/badge/English-%230010a0.svg?style=for-the-badge&logo=<badge>&logoColor=white)                   | `![English](https://img.shields.io/badge/English-%23#0010a0.svg?style=for-the-badge&logo=<badge>&logoColor=white)`                   |
-| French   | ![French](https://img.shields.io/badge/French-%23000000.svg?style=for-the-badge&logo=<badge>&logoColor=white)          | `![French](https://img.shields.io/badge/French-%23#000000.svg?style=for-the-badge&logo=<badge>&logoColor=white)`          |
-| German    | ![German](https://img.shields.io/badge/German-%23ffae00.svg?style=for-the-badge&logo=<badge>&logoColor=black)             | `![German](https://img.shields.io/badge/German-%23#ffae00.svg?style=for-the-badge&logo=<badge>&logoColor=black)`
-| Hindi | ![Hindi](https://img.shields.io/badge/Hindi-%23ae00ff.svg?style=for-the-badge&logo=<badge>&logoColor=black) | `![Hindi](https://img.shields.io/badge/Hindi-%23#ae00ff.svg?style=for-the-badge&logo=<badge>&logoColor=black)` |
-| Portuguese   | ![Portuguese](https://img.shields.io/badge/Portuguese-%23690000.svg?style=for-the-badge&logo=<badge>&logoColor=white)         | `![Portuguese](https://img.shields.io/badge/Portuguese-%23#690000.svg?style=for-the-badge&logo=<badge>&logoColor=white)`         |
-| Russian       | ![Russian](https://img.shields.io/badge/Russian-%23ffffff.svg?style=for-the-badge&logo=<badge>&logoColor=black)                      | `![Russian](https://img.shields.io/badge/Russian-%23ffffff.svg?style=for-the-badge&logo=<badge>&logoColor=black)`                      |
-| Spanish       | ![Spanish](https://img.shields.io/badge/Spanish-%23ffff00.svg?style=for-the-badge&logo=<badge>&logoColor=black)                      | `![Spanish](https://img.shields.io/badge/Spanish-%23ffff00.svg?style=for-the-badge&logo=<badge>&logoColor=black)`                      |
-
 [(Back to top)](#table-of-contents)
 
 ### 🖥️ ML/DL
@@ -1027,6 +1009,21 @@ Zod                | ![Zod](https://img.shields.io/badge/zod-%233068b7.svg?style
 | Oppo     | ![Oppo](https://img.shields.io/badge/Oppo-%231EA366.svg?style=for-the-badge&logo=oppo&logoColor=white)          | `![Oppo](https://img.shields.io/badge/Oppo-%231EA366.svg?style=for-the-badge&logo=oppo&logoColor=white)`          |
 | Vivo     | ![Vivo](https://img.shields.io/badge/Vivo-%2300BFFF.svg?style=for-the-badge&logo=vivo&logoColor=black)          | `![Vivo](https://img.shields.io/badge/Vivo-%2300BFFF.svg?style=for-the-badge&logo=vivo&logoColor=black)`          |
 
+[(Back to top)](#table-of-contents)
+
+### 🗣 Spoken Languages
+
+| Name         | Badge                                                                                                                      | Markdown                                                                                                                     |
+| ------------ | -------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| Arabic    | ![Arabic](https://img.shields.io/badge/Arabic-%23046005.svg?style=for-the-badge&logo=<badge>&logoColor=white)      | `![Arabic](https://img.shields.io/badge/Arabic-%23#046005.svg?style=for-the-badge&logo=<badge>&logoColor=white)`      |
+| Chinese    | ![Chinese](https://img.shields.io/badge/Chinese-%23c80000.svg?style=for-the-badge&logo=<badge>&logoColor=white)      | `![Chinese](https://img.shields.io/badge/Chinese-%23#c80000.svg?style=for-the-badge&logo=<badge>&logoColor=white)`      |
+| English      | ![English](https://img.shields.io/badge/English-%230010a0.svg?style=for-the-badge&logo=<badge>&logoColor=white)                   | `![English](https://img.shields.io/badge/English-%23#0010a0.svg?style=for-the-badge&logo=<badge>&logoColor=white)`                   |
+| French   | ![French](https://img.shields.io/badge/French-%23000000.svg?style=for-the-badge&logo=<badge>&logoColor=white)          | `![French](https://img.shields.io/badge/French-%23#000000.svg?style=for-the-badge&logo=<badge>&logoColor=white)`          |
+| German    | ![German](https://img.shields.io/badge/German-%23ffae00.svg?style=for-the-badge&logo=<badge>&logoColor=black)             | `![German](https://img.shields.io/badge/German-%23#ffae00.svg?style=for-the-badge&logo=<badge>&logoColor=black)`
+| Hindi | ![Hindi](https://img.shields.io/badge/Hindi-%23ae00ff.svg?style=for-the-badge&logo=<badge>&logoColor=black) | `![Hindi](https://img.shields.io/badge/Hindi-%23#ae00ff.svg?style=for-the-badge&logo=<badge>&logoColor=black)` |
+| Portuguese   | ![Portuguese](https://img.shields.io/badge/Portuguese-%23690000.svg?style=for-the-badge&logo=<badge>&logoColor=white)         | `![Portuguese](https://img.shields.io/badge/Portuguese-%23#690000.svg?style=for-the-badge&logo=<badge>&logoColor=white)`         |
+| Russian       | ![Russian](https://img.shields.io/badge/Russian-%23ffffff.svg?style=for-the-badge&logo=<badge>&logoColor=black)                      | `![Russian](https://img.shields.io/badge/Russian-%23ffffff.svg?style=for-the-badge&logo=<badge>&logoColor=black)`                      |
+| Spanish       | ![Spanish](https://img.shields.io/badge/Spanish-%23ffff00.svg?style=for-the-badge&logo=<badge>&logoColor=black)                      | `![Spanish](https://img.shields.io/badge/Spanish-%23ffff00.svg?style=for-the-badge&logo=<badge>&logoColor=black)`                      |
 
 [(Back to top)](#table-of-contents)
 


### PR DESCRIPTION
I added Arabic, Chinese, English, French, German, Hindi, Portuguese, Russian, and Spanish badges under the "Spoken Language category.

The languages within the category and the category itself are both arranged alphabetically.

I also clarified/edited the old "Languages" tab to mean and say "Programming Languages". I moved this "new" category to it's appropriate spot as well.