### PR TITLE
More CAD Badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ You can reach me on [Twitter @ileriayooo](https://twitter.com/Ileriayooo)
 | OpenSCAD | ![OpenSCAD](https://img.shields.io/badge/openscad-%23F9D72C.svg?style=for-the-badge&logo=openscad&logoColor=black&logoSize=auto) | `![OpenSCAD](https://img.shields.io/badge/openscad-%23F9D72C.svg?style=for-the-badge&logo=openscad&logoColor=black&logoSize=auto)` |
 | Rhinoceros | ![Rhinoceros](https://img.shields.io/badge/Rhinoceros-%23801010.svg?style=for-the-badge&logo=rhinoceros&logoColor=white) | `![Rhinoceros](https://img.shields.io/badge/Rhinoceros-%23801010.svg?style=for-the-badge&logo=rhinoceros&logoColor=white)` |
 | SketchUp | ![SketchUp](https://img.shields.io/badge/SketchUp-%23005F9E.svg?style=for-the-badge&logo=sketchup&logoColor=white) | `![SketchUp](https://img.shields.io/badge/SketchUp-%23005F9E.svg?style=for-the-badge&logo=sketchup&logoColor=white)` |
+| Tinkercad | ![Tinkercad](https://img.shields.io/badge/Tinkercad-%231477D1.svg?style=for-the-badge&logo=tinkercad&logoColor=white) | `![Tinkercad](https://img.shields.io/badge/Tinkercad-%231477D1.svg?style=for-the-badge&logo=tinkercad&logoColor=white)` |
 
 [(Back to top)](#table-of-contents)
    


### PR DESCRIPTION
## Description
Added some more CAD badges and also fixed the TOC entry spacing.

## Info
<!-- This is an example. Replace with badge details-->
| Name | Category | Background Color | Logo Color |
|:--:|:--:|:--:|:--:|
| Archicad | CAD | `#2D50A5` | `#ffffff` |
| AutoCAD | CAD | `#E51050` | `#ffffff` |
| AutoDesk | CAD | `#000000` | `#ffffff` |
| Autodesk Revit | CAD | `#186BFF` | `#ffffff` |
| FreeCAD | CAD | `#418FDE` | `#ffffff` |
| Microstation | CAD | `#62BB47` | `#ffffff` |
| OpenSCAD | CAD | `#F9D72C` | `#000000` |
| Rhinoceros | CAD | `#801010` | `#ffffff` |
| SketchUp | CAD | `#005F9E` | `#ffffff` |
| Tinkercad | CAD | `#1477D1` | `#ffffff` |


## Preview
<!-- This is an example. Replace with badge url-->
| Name | Badge | URL |
| ------ | ----- | --- |
| Archicad | ![Archicad](https://img.shields.io/badge/archicad-%232D50A5.svg?style=for-the-badge&logo=archicad&logoColor=white) | `![Archicad](https://img.shields.io/badge/archicad-%232D50A5.svg?style=for-the-badge&logo=archicad&logoColor=white)`|
| AutoCAD | ![AutoCAD](https://img.shields.io/badge/autocad-%23E51050.svg?style=for-the-badge&logo=autocad&logoColor=white) | `![AutoCAD](https://img.shields.io/badge/autocad-%23E51050.svg?style=for-the-badge&logo=autocad&logoColor=white)`|
| AutoDesk | ![AutoDesk](https://img.shields.io/badge/autodesk-%23000000.svg?style=for-the-badge&logo=autodesk&logoColor=white) | `![AutoDesk](https://img.shields.io/badge/autodesk-%23000000.svg?style=for-the-badge&logo=autodesk&logoColor=white)`|
| Autodesk Revit | ![Autodesk Revit](https://img.shields.io/badge/Autodesk_Revit-%23186BFF.svg?style=for-the-badge&logo=autodeskrevit&logoColor=white) | `![Autodesk Revit](https://img.shields.io/badge/Autodesk_Revit-%23186BFF.svg?style=for-the-badge&logo=autodeskrevit&logoColor=white)`|
| FreeCAD | ![FreeCAD](https://img.shields.io/badge/freecad-%23418FDE.svg?style=for-the-badge&logo=freecad&logoColor=white) | `![FreeCAD](https://img.shields.io/badge/freecad-%23418FDE.svg?style=for-the-badge&logo=freecad&logoColor=white)`|
| Microstation | ![Microstation](https://img.shields.io/badge/microstation-%2362BB47.svg?style=for-the-badge&logo=microstation&logoColor=white) | `![Microstation](https://img.shields.io/badge/microstation-%2362BB47.svg?style=for-the-badge&logo=microstation&logoColor=white)` |
| OpenSCAD | ![OpenSCAD](https://img.shields.io/badge/openscad-%23F9D72C.svg?style=for-the-badge&logo=openscad&logoColor=black&logoSize=auto) | `![OpenSCAD](https://img.shields.io/badge/openscad-%23F9D72C.svg?style=for-the-badge&logo=openscad&logoColor=black&logoSize=auto)` |
| Rhinoceros | ![Rhinoceros](https://img.shields.io/badge/Rhinoceros-%23801010.svg?style=for-the-badge&logo=rhinoceros&logoColor=white) | `![Rhinoceros](https://img.shields.io/badge/Rhinoceros-%23801010.svg?style=for-the-badge&logo=rhinoceros&logoColor=white)` |
| SketchUp | ![SketchUp](https://img.shields.io/badge/SketchUp-%23005F9E.svg?style=for-the-badge&logo=sketchup&logoColor=white) | `![SketchUp](https://img.shields.io/badge/SketchUp-%23005F9E.svg?style=for-the-badge&logo=sketchup&logoColor=white)` |
| Tinkercad | ![Tinkercad](https://img.shields.io/badge/Tinkercad-%231477D1.svg?style=for-the-badge&logo=tinkercad&logoColor=white) | `![Tinkercad](https://img.shields.io/badge/Tinkercad-%231477D1.svg?style=for-the-badge&logo=tinkercad&logoColor=white)` |


