### PR TITLE
docs: add practical badge usage guide to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,43 @@ https://shields.io/badge/style-flat-green?logo=appveyor&style=flat
 
 </details>
 
+<details>
+<summary>👇 Practical Badge Usage Tips</summary>
+<hr>
+
+### 1. Strengthen Your GitHub Profile README
+
+Create a repository with the same name as your GitHub username.  
+This allows you to customize your profile using a `README.md`.
+
+Use badges to clearly show:
+- The languages you primarily use
+- Frameworks you specialize in
+- Tools and platforms you are comfortable with
+
+This helps visitors instantly understand your technical focus and strengths.
+
+Keep it focused. Show direction, not everything you’ve ever tried.
+
+---
+
+### 2. Summarize Project Technologies at a Glance
+
+In each project’s `README.md`, add a Tech Stack section.
+
+Use badges to display:
+- Programming languages
+- Frameworks
+- Databases
+- Infrastructure or tools
+
+This allows others to quickly understand what the project was built with.
+
+A clean, well-structured badge section improves clarity and professionalism.
+
+</details>
+
+
 ## Contribution
 
 The project has a separate contribution file. Please adhere to the steps listed in the separate contributions [file](./CONTRIBUTING.md)


### PR DESCRIPTION
Summary
Added a new section titled "Practical Badge Usage Tips" to provide structured guidance on how to use badges effectively in GitHub profile and project README files.

Details
The section focuses on:
- Showcasing technical stack clearly in project READMEs
- Using badges to communicate technical direction in profile README
- Improving clarity and professionalism through minimal, purpose-driven badge usage

The content avoids decorative or redundant usage and emphasizes practical application.

Impact
This is a documentation-only update.
No functional or structural changes were made.

Please let me know if any revisions are needed. I’m happy to adjust accordingly.